### PR TITLE
feat(bot-v-bot): /spectate/[matchId] route + homepage CTA rewire (FE-1, FE-2)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,24 +8,45 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { useStartBotMatch } from '@/hooks/useGraphQL'
 
+// Backend BE-5 asserts these are the five strategies the engine supports
+// (StartBotMatchResult.availableStrategies). We seed the dropdowns with the
+// same five so the page works before the first mutation completes, and we
+// replace the list from the response on submit so a future backend change
+// (new strategy added, old one removed) flows through without a code change.
+const DEFAULT_STRATEGIES = ['baseline', 'heuristic', 'random', 'aggro', 'control'] as const
+const DEFAULT_STRATEGY_A = 'aggro'
+const DEFAULT_STRATEGY_B = 'control'
+
 export default function Home() {
   const router = useRouter()
   const [startBotMatch, { loading: startingBotMatch }] = useStartBotMatch()
   const [botError, setBotError] = useState<string | null>(null)
+  const [strategyA, setStrategyA] = useState<string>(DEFAULT_STRATEGY_A)
+  const [strategyB, setStrategyB] = useState<string>(DEFAULT_STRATEGY_B)
+  const [availableStrategies, setAvailableStrategies] = useState<string[]>([
+    ...DEFAULT_STRATEGIES,
+  ])
 
   const handleStartBotMatch = async () => {
     setBotError(null)
     try {
       const { data } = await startBotMatch({
         variables: {
-          strategyA: 'aggro',
-          strategyB: 'control',
+          strategyA,
+          strategyB,
         },
       })
       const payload = data?.startBotMatch
-      const spectatorPath: string | undefined =
-        payload?.spectatorPath ||
-        (payload?.matchId ? `/game/${encodeURIComponent(payload.matchId)}` : undefined)
+      // Replace the dropdown options from the backend's reply so any future
+      // change to the supported strategy list is reflected here without a
+      // frontend redeploy. Defaults stay if the field is missing.
+      if (Array.isArray(payload?.availableStrategies) && payload.availableStrategies.length > 0) {
+        setAvailableStrategies(payload.availableStrategies)
+      }
+      // Trust the backend's spectatorPath. BE-3 made this canonical
+      // (/spectate/<matchId>); the old /game/<matchId> fallback would
+      // re-introduce the participant-only-view bug (spec D1) so it is gone.
+      const spectatorPath: string | undefined = payload?.spectatorPath
       if (!spectatorPath) {
         setBotError('Bot match could not be started.')
         return
@@ -64,9 +85,41 @@ export default function Home() {
                   onClick={handleStartBotMatch}
                   disabled={startingBotMatch}
                 >
-                  {startingBotMatch ? 'Starting bots...' : 'Start bot match'}
+                  {startingBotMatch ? 'Starting bot vs bot...' : 'Start Bot vs Bot'}
                 </button>
               </p>
+              <div className="bot-strategy-pickers" style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'center', marginTop: '0.5rem' }}>
+                <label style={{ display: 'inline-flex', flexDirection: 'column', gap: '0.25rem' }}>
+                  <span className="muted small">Bot A</span>
+                  <select
+                    value={strategyA}
+                    onChange={(event) => setStrategyA(event.target.value)}
+                    disabled={startingBotMatch}
+                    aria-label="Bot A strategy"
+                  >
+                    {availableStrategies.map((value) => (
+                      <option key={`a-${value}`} value={value}>
+                        {value}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label style={{ display: 'inline-flex', flexDirection: 'column', gap: '0.25rem' }}>
+                  <span className="muted small">Bot B</span>
+                  <select
+                    value={strategyB}
+                    onChange={(event) => setStrategyB(event.target.value)}
+                    disabled={startingBotMatch}
+                    aria-label="Bot B strategy"
+                  >
+                    {availableStrategies.map((value) => (
+                      <option key={`b-${value}`} value={value}>
+                        {value}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
               {botError && (
                 <p className="muted small" aria-live="polite">
                   {botError}

--- a/app/spectate/[matchId]/page.tsx
+++ b/app/spectate/[matchId]/page.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useMemo } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+import GameBoard from '@/components/GameBoard'
+import { useAuth } from '@/hooks/useAuth'
+import { useMatch } from '@/hooks/useGraphQL'
+
+/**
+ * Live spectate page for a single match.
+ *
+ * Route: /spectate/[matchId]
+ *
+ * Public, no RequireAuth wrapper. Anyone with the link can watch a bot
+ * match (or any in-progress match) play out on the real GameBoard, fed by
+ * the gameStateChanged subscription that the engine publishes after every
+ * dispatched action.
+ *
+ * The board needs a `playerId` to seed perspective even though spectator
+ * mode skips the player-scoped query and subscription. We resolve the first
+ * bot's id from the match query (match.players[0]); if the query has not
+ * resolved yet we fall back to the signed-in viewer's id (which is fine,
+ * spectator mode does not use it for any backend call), and finally to an
+ * empty string. GameBoard's spectator branch (GameBoard.tsx around 2548)
+ * zeroes out livePlayerId regardless, so this is purely a perspective hint.
+ */
+export default function SpectateMatchPage() {
+  const { user } = useAuth()
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+
+  const matchId = useMemo(() => {
+    const fromQuery = searchParams.get('matchId')
+    if (fromQuery) {
+      return fromQuery
+    }
+    if (!pathname) {
+      return ''
+    }
+    const segments = pathname.split('/').filter(Boolean)
+    if (segments.length >= 2 && segments[0] === 'spectate') {
+      return segments[1] ?? ''
+    }
+    return ''
+  }, [searchParams, pathname])
+
+  const { data: matchData } = useMatch(matchId || null)
+  const firstBotPlayerId: string | undefined = matchData?.match?.players?.[0]?.playerId
+
+  if (!matchId) {
+    return (
+      <main className="game-screen container">
+        <div className="queue-waiting" aria-live="polite">
+          <strong>No match id in the URL.</strong>
+          <span>Open a /spectate link from the homepage or the recent matches list.</span>
+        </div>
+      </main>
+    )
+  }
+
+  const perspectivePlayerId = firstBotPlayerId ?? user?.userId ?? ''
+
+  return (
+    <main className="game-screen container">
+      <div className="game-screen__board">
+        <GameBoard
+          matchId={matchId}
+          playerId={perspectivePlayerId}
+          spectator
+        />
+      </div>
+    </main>
+  )
+}

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -1531,6 +1531,7 @@ export const START_BOT_MATCH = gql`
       players
       strategies
       spectatorPath
+      availableStrategies
     }
   }
 `;


### PR DESCRIPTION
## Summary

Frontend half of the bot-vs-bot flow (spec sections 5.2 FE-1 and FE-2). Pairs with backend PR #2 (BE-3, BE-4, BE-5).

- **FE-1**: New public `/spectate/[matchId]` route mounts `<GameBoard spectator/>`. Resolves perspective from `match.players[0]` (first bot), falls back to the signed-in user's id, then empty string. Spectator mode in GameBoard already skips `usePlayerMatch` and the player-scoped subscription, so the perspective id is purely a hint.
- **FE-2**: Homepage CTA renamed to "Start Bot vs Bot" / "Starting bot vs bot..." per spec D3. Removed the `/game/<matchId>` fallback so the participant-only-view bug (D1) cannot return when the backend always emits `/spectate/<matchId>`. Two `<select/>` dropdowns added for strategyA / strategyB, seeded with the five engine strategies and replaced from `availableStrategies` on each submit.

## Backend contract consumed

- `Mutation.startBotMatch` now returns `availableStrategies: [String!]!`. The mutation document was extended to request that field. Defaults stay `aggro` vs `control`.
- `spectatorPath` is trusted as canonical (BE-3 always returns `/spectate/<matchId>`). No client-side fallback.
- `Query.match(matchId)` is used to read `players[0].playerId` for the perspective id; no `playerMatch` call is made in spectator mode (covered by BE-4 if anything else hits it).

## Out of scope (per spec)

- FE-3 spectate-list routing by status
- FE-4 lib/replay/reducer.ts deletion
- FE-5 live spectate controls (pause/scrub)
- FE-6 strategy labels in the HUD
- Any QA Playwright e2e (QA owner)

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` green; `/spectate/[matchId]` listed in route table as dynamic
- [x] grep `spectator\s*$|spectator\s*/` against the new page returns a hit
- [x] grep `Start Bot vs Bot` against `app/page.tsx` returns a hit
- [ ] Manual smoke test once backend PR #2 is deployed: click "Start Bot vs Bot" on `/`, land on `/spectate/<id>`, watch `gameStateChanged` paint
- [ ] Playwright e2e (QA, separate ticket)

## Notes

- Branched off `origin/feature/upgraded-game-logic`. PR targets the same branch to match the existing stacking pattern (sibling PR #1 also targets `feature/upgraded-game-logic`).
- No frontend test framework (Vitest/Jest) is wired up in this repo, so verification was build + tsc + greps. Existing `playwright` package is installed but no `*.spec.*` files exist on disk — Playwright e2e is QA's deliverable per spec.