### PR TITLE
ci: land frontend build workflow + home-page bot CTA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Riftbound Frontend CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # TODO(FE): re-add `npm run lint` once an ESLint config lands.
+      # `next lint` currently prompts interactively for first-run setup and
+      # cannot pass in non-interactive CI without .eslintrc.json + the
+      # `eslint` + `eslint-config-next` devDependencies.
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: http://localhost:3000
+          NEXT_PUBLIC_WS_BASE_URL: ws://localhost:3000

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,15 @@ import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
+import { useMutation } from '@apollo/client'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import ReplayDrawer from '@/components/ReplayDrawer'
-import { useStartBotMatch } from '@/hooks/useGraphQL'
+import { useActiveBotMatches, useStartBotMatch } from '@/hooks/useGraphQL'
+import {
+  CANCEL_BOT_MATCH,
+  CANCEL_ALL_BOT_MATCHES,
+} from '@/lib/graphql/queries'
 
 // Backend BE-5 asserts these are the five strategies the engine supports
 // (StartBotMatchResult.availableStrategies). We seed the dropdowns with the
@@ -17,6 +22,15 @@ import { useStartBotMatch } from '@/hooks/useGraphQL'
 const DEFAULT_STRATEGIES = ['baseline', 'heuristic', 'random', 'aggro', 'control'] as const
 const DEFAULT_STRATEGY_A = 'aggro'
 const DEFAULT_STRATEGY_B = 'control'
+
+interface BotMatchSummary {
+  matchId: string
+  players: string[]
+  strategies: string[]
+  status: string
+  winner: string | null
+  reason: string | null
+}
 
 export default function Home() {
   const router = useRouter()
@@ -28,6 +42,15 @@ export default function Home() {
     ...DEFAULT_STRATEGIES,
   ])
 
+  const { data: activeData, refetch: refetchActive } = useActiveBotMatches({ pollMs: 4000 })
+
+  const [cancelBotMatch, { loading: cancelling }] = useMutation<{
+    cancelBotMatch: boolean
+  }>(CANCEL_BOT_MATCH)
+  const [cancelAllBotMatches, { loading: cancellingAll }] = useMutation<{
+    cancelAllBotMatches: number
+  }>(CANCEL_ALL_BOT_MATCHES)
+
   const handleStartBotMatch = async () => {
     setBotError(null)
     try {
@@ -38,9 +61,6 @@ export default function Home() {
         },
       })
       const payload = data?.startBotMatch
-      // Replace the dropdown options from the backend's reply so any future
-      // change to the supported strategy list is reflected here without a
-      // frontend redeploy. Defaults stay if the field is missing.
       if (Array.isArray(payload?.availableStrategies) && payload.availableStrategies.length > 0) {
         setAvailableStrategies(payload.availableStrategies)
       }
@@ -52,6 +72,7 @@ export default function Home() {
         setBotError('Bot match could not be started.')
         return
       }
+      await refetchActive()
       router.push(spectatorPath)
     } catch (error) {
       const message =
@@ -59,6 +80,32 @@ export default function Home() {
       setBotError(message)
     }
   }
+
+  const handleCancel = async (matchId: string) => {
+    try {
+      await cancelBotMatch({ variables: { matchId } })
+      await refetchActive()
+    } catch (err) {
+      console.error('cancelBotMatch failed', err)
+    }
+  }
+
+  const handleCancelAll = async () => {
+    try {
+      await cancelAllBotMatches()
+      await refetchActive()
+    } catch (err) {
+      console.error('cancelAllBotMatches failed', err)
+    }
+  }
+
+  const summaries: BotMatchSummary[] = activeData?.activeBotMatches ?? []
+  const activeMatches = summaries.filter(
+    (m) => m.status === 'running' || m.status === 'initializing'
+  )
+  const recentlyFinished = summaries
+    .filter((m) => m.status === 'completed' || m.status === 'crashed')
+    .slice(0, 5)
 
   return (
     <>
@@ -165,6 +212,147 @@ export default function Home() {
           </div>
         </section>
 
+        <section className="container" style={{ padding: '32px 0' }}>
+          <div
+            style={{
+              border: '1px solid rgba(255, 255, 255, 0.08)',
+              borderRadius: 12,
+              padding: 24,
+              background: 'rgba(255, 255, 255, 0.02)',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                flexWrap: 'wrap',
+                marginBottom: 8,
+              }}
+            >
+              <h4 style={{ margin: 0 }}>
+                Active bot matches{' '}
+                <span style={{ opacity: 0.6, fontWeight: 400, fontSize: '0.85em' }}>
+                  ({activeMatches.length})
+                </span>
+              </h4>
+              {activeMatches.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={handleCancelAll}
+                  disabled={cancellingAll}
+                  style={{
+                    fontSize: 12,
+                    padding: '6px 12px',
+                    borderRadius: 6,
+                    border: '1px solid rgba(255, 136, 136, 0.5)',
+                    background: 'transparent',
+                    color: '#ff8888',
+                    cursor: cancellingAll ? 'wait' : 'pointer',
+                    opacity: cancellingAll ? 0.7 : 1,
+                  }}
+                >
+                  {cancellingAll ? 'Cancelling...' : `Cancel all (${activeMatches.length})`}
+                </button>
+              ) : null}
+            </div>
+            {activeMatches.length === 0 ? (
+              <p style={{ opacity: 0.7, margin: 0 }}>
+                No bot matches running right now. Start one above.
+              </p>
+            ) : (
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
+                {activeMatches.map((m) => (
+                  <li
+                    key={m.matchId}
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 12,
+                      padding: '10px 14px',
+                      border: '1px solid rgba(255, 255, 255, 0.08)',
+                      borderRadius: 8,
+                      background: 'rgba(255, 255, 255, 0.03)',
+                    }}
+                  >
+                    <div style={{ display: 'grid', gap: 2 }}>
+                      <strong style={{ fontFamily: 'monospace', fontSize: 13 }}>{m.matchId}</strong>
+                      <span style={{ fontSize: 12, opacity: 0.75 }}>
+                        {m.strategies.join(' vs ')} - status {m.status}
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                      <Link
+                        className="cta"
+                        href={`/spectate/${encodeURIComponent(m.matchId)}`}
+                        style={{ fontSize: 13, padding: '6px 12px' }}
+                      >
+                        Spectate
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => handleCancel(m.matchId)}
+                        disabled={cancelling}
+                        style={{
+                          fontSize: 12,
+                          padding: '6px 10px',
+                          borderRadius: 6,
+                          border: '1px solid rgba(255, 136, 136, 0.5)',
+                          background: 'transparent',
+                          color: '#ff8888',
+                          cursor: cancelling ? 'wait' : 'pointer',
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {recentlyFinished.length > 0 ? (
+              <details style={{ marginTop: 16 }}>
+                <summary style={{ cursor: 'pointer', opacity: 0.8 }}>
+                  Recently finished ({recentlyFinished.length})
+                </summary>
+                <ul style={{ listStyle: 'none', padding: 0, marginTop: 8, display: 'grid', gap: 6 }}>
+                  {recentlyFinished.map((m) => (
+                    <li
+                      key={m.matchId}
+                      style={{
+                        padding: '8px 12px',
+                        border: '1px solid rgba(255, 255, 255, 0.06)',
+                        borderRadius: 6,
+                        fontSize: 12,
+                        opacity: 0.85,
+                        display: 'flex',
+                        gap: 8,
+                        flexWrap: 'wrap',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <span style={{ fontFamily: 'monospace' }}>{m.matchId}</span>
+                      <span>
+                        {m.status} - winner: {m.winner ?? 'n/a'} - {m.reason ?? ''}
+                      </span>
+                      <Link
+                        href={`/replay/${encodeURIComponent(m.matchId)}`}
+                        style={{ color: 'inherit', textDecoration: 'underline' }}
+                      >
+                        replay
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            ) : null}
+          </div>
+        </section>
+
         <section className="features container">
           <h3>Features</h3>
           <div className="grid">
@@ -185,9 +373,7 @@ export default function Home() {
       </main>
       {/* Recent-matches drawer. Clicking a completed match routes to
           /replay/<id>, which renders the persisted engine frames on the
-          real GameBoard via setSpectatorOverride. The drawer itself was
-          shipped in PR #1 ("mount replay drawer inside the gameboard");
-          mounting it here brings the same entry point to the homepage. */}
+          real GameBoard via setSpectatorOverride. */}
       <ReplayDrawer />
       <Footer />
     </>

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -1562,3 +1562,15 @@ export const START_BOT_MATCH = gql`
     }
   }
 `;
+
+export const CANCEL_BOT_MATCH = gql`
+  mutation CancelBotMatch($matchId: ID!) {
+    cancelBotMatch(matchId: $matchId)
+  }
+`;
+
+export const CANCEL_ALL_BOT_MATCHES = gql`
+  mutation CancelAllBotMatches {
+    cancelAllBotMatches
+  }
+`;


### PR DESCRIPTION
## What this PR lands

Two commits on top of current `origin/main`:

1. **ci: add frontend build workflow** — `.github/workflows/ci.yml` running `npm ci` + `next build` on push and PR to `main` / `develop` (Node 20, npm cache). `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_WS_BASE_URL` are pinned for the build step so missing env at compile time is not a failure mode.
2. **feat(home): active bot matches list with cancel controls** — extends the home page with a live list of in-progress bot-vs-bot matches (polls every 4s via `useActiveBotMatches`), per-row `Spectate` + `Cancel` buttons, a `Cancel all` button, and a collapsible `Recently finished` section. Adds `CANCEL_BOT_MATCH` and `CANCEL_ALL_BOT_MATCHES` mutations alongside the existing bot-match query.

## Divergence that was reconciled

`main` (local) had diverged 2 ahead / 1 behind `origin/main`:

- **1 behind:** PR #3 (`feat(replay): consume persistent matchFrames on spectate + replay drawer`) was already merged on `origin/main`, so the first local-ahead commit `8052831` ("hidden-card flow, GraphQL wiring, game-board polish, CI workflow") was mostly subsumed by PR #3's first commit ("Added hidden card mechanic"). After resolving the merge, the only net change from `8052831` is the CI workflow file.
- **2 ahead:** `8052831` and `2735deb`. Cherry-picked onto a fresh branch off `origin/main` so this PR is a clean fast-forward against `main` and the landing branch can merge without a merge commit. Conflicts in `components/GameBoard.tsx` were resolved by taking `origin/main` (PR #3's `replayMode || spectatorMode` guards are additive and preserve the hidden-card handlers). Conflicts in `app/page.tsx` were resolved by keeping PR #3's strategy dropdowns + `ReplayDrawer` and appending the active-matches / cancel-UX section below the hero.

## Lint

`npm run lint` is intentionally NOT in CI yet: the repo has no `.eslintrc.json` and no `eslint` dependency, so `next lint` prompts interactively on first run and would hang the workflow. A follow-up PR will add the config and re-enable the lint step.

## Card regeneration

**Not in CI and not blocking this PR.** `src/lib/cardCatalog.ts` expects `data/cards.enriched.json` and its error message references `npm run generate:cards`, but no such script or generator exists in this repo. The build passes without the file because no page imports `cardCatalog` at build time (server-only code path). Runtime usage of server routes that touch `cardCatalog` would fail until the file is present.

HUMAN_ACTION_NEEDED: add a card-generation step to CI once the generator is decided on. Options (pick one):
- commit a `scripts/generate-cards.mjs` + add `npm run generate:cards` to `package.json`, then run it in CI before build
- fetch `data/cards.enriched.json` from the backend repo/S3 during CI and cache it
- move the catalog loader out of the frontend entirely and consume cards via GraphQL

## Context

Unblocks QA E2E task `qa-e2e-2026-04-24-1` (aborted because `.github/workflows/ci.yml` and `.github` were empty on origin/main). Postmortem: `nexus-data/tasks/qa-abort.md`.

## Test plan

- [x] `NEXT_PUBLIC_API_BASE_URL=http://localhost:3000 NEXT_PUBLIC_WS_BASE_URL=ws://localhost:3000 npm run build` passes locally
- [x] No unresolved merge markers in `components/GameBoard.tsx`, `app/page.tsx`, `lib/graphql/queries.ts`
- [x] No duplicate exports in `lib/graphql/queries.ts` (GET_ACTIVE_BOT_MATCHES, START_BOT_MATCH appear once each)
- [ ] First CI run green on `main` after merge
- [ ] QA E2E re-run dispatched
