### PR TITLE
fix(ci): exclude infrastructure and scripts from tsc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,8 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "infrastructure",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## Fix: exclude infrastructure and scripts from Next.js tsc

First CI run on `main` (PR #4 merge commit 625ad1f) failed the `Build` step with:

```
./infrastructure/cdk/bin/riftbound-ui-infra.ts:3:22
Type error: Cannot find module 'aws-cdk-lib' or its corresponding type declarations.
```

The Next.js build succeeds in compilation but the post-compile type-check walks into `infrastructure/cdk/bin/riftbound-ui-infra.ts` and `aws-cdk-lib` is not installed by the root `npm ci` (its `node_modules` is nested under `infrastructure/cdk`). Locally the build passes only because `infrastructure/cdk/node_modules/` is already populated from an earlier `aws-cdk` install.

This PR adds `infrastructure` and `scripts` to `tsconfig.exclude`. Neither directory is part of the Next.js app:
- `infrastructure/` — CDK stack definition, compiled by its own nested `tsconfig.json` + `aws-cdk-lib` install.
- `scripts/` — a Node-only `qa-visual-audit.mjs` and a shell deploy script.

## Test plan

- [x] `NEXT_PUBLIC_API_BASE_URL=http://localhost:3000 NEXT_PUBLIC_WS_BASE_URL=ws://localhost:3000 npm run build` passes locally
- [ ] CI green on the PR
- [ ] CI green on main after merge
